### PR TITLE
[-] BO : fixed mysql 5.7 "virtual" is a reserved keyword

### DIFF
--- a/controllers/admin/AdminAttachmentsController.php
+++ b/controllers/admin/AdminAttachmentsController.php
@@ -43,8 +43,8 @@ class AdminAttachmentsControllerCore extends AdminController
         $this->addRowAction('view');
         $this->addRowAction('delete');
 
-        $this->_select = 'IFNULL(virtual.products, 0) as products';
-        $this->_join = 'LEFT JOIN (SELECT id_attachment, COUNT(*) as products FROM '._DB_PREFIX_.'product_attachment GROUP BY id_attachment) virtual ON a.id_attachment = virtual.id_attachment';
+        $this->_select = 'IFNULL(virtual_product_attachment.products, 0) as products';
+        $this->_join = 'LEFT JOIN (SELECT id_attachment, COUNT(*) as products FROM '._DB_PREFIX_.'product_attachment GROUP BY id_attachment) AS virtual_product_attachment ON a.id_attachment = virtual_product_attachment.id_attachment';
         $this->_use_found_rows = false;
 
         $this->fields_list = array(
@@ -53,7 +53,7 @@ class AdminAttachmentsControllerCore extends AdminController
                 'align' => 'center',
                 'class' => 'fixed-width-xs'
             ),
-            'name' => array(
+            'name' => array(v
                 'title' => $this->l('Name')
             ),
             'file' => array(
@@ -66,7 +66,7 @@ class AdminAttachmentsControllerCore extends AdminController
             'products' => array(
                 'title' => $this->l('Associated with'),
                 'suffix' => $this->l('product(s)'),
-                'filter_key' => 'virtual!products',
+                'filter_key' => 'virtual_product_attachment!products',
             ),
         );
 


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! -->

Please take the time to edit the "Answers" rows with the necessary information:

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | Use the "develop" branch if you target PrestaShop 1.7; use the "1.6.1.x" branch if you target PrestaShop 1.6 (bugfixes only)
| Description?  | Please be specific when describing the PR. <br/> Every detail will helps: version, browser, specific module/theme, etc.
| Type?         | bug fix/improvement/new feature
| Category?     | See [the Category list](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message), ex: BO
| BC breaks?    | Does it break backward compatibility? yes/no
| Deprecations? | Does it deprecate an existing feature? yes/no
| Fixed ticket? | (optional) If this PR fixes a Forge ticket, please add its complete URL.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [the PSR-2 Coding Style](http://doc.prestashop.com/display/PS16/Coding+Standards)!
* Your commit MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)

fix virtual, a reserved keyword in mysql 5.7